### PR TITLE
use different suffix depending on database system for file being dumped

### DIFF
--- a/src/Tasks/Backup/BackupJob.php
+++ b/src/Tasks/Backup/BackupJob.php
@@ -196,7 +196,18 @@ class BackupJob
         return $this->dbDumpers->map(function (DbDumper $dbDumper) {
             consoleOutput()->info("Dumping database {$dbDumper->getDbName()}...");
 
-            $fileName = $dbDumper->getDbName().'.sql';
+            switch(class_basename($dbDumper)) {
+                case "MySql":
+                    $extension = "sql";
+                    break;
+                case "MongoDb":
+                    $extension = "mongo";
+                    break;
+                default:
+                    $extension = "sql";
+            }
+
+            $fileName = $dbDumper->getDbName().'.'.$extension;
 
             $temporaryFilePath = $this->temporaryDirectory->path('db-dumps'.DIRECTORY_SEPARATOR.$fileName);
 


### PR DESCRIPTION
before it would always default to .sql which caused a loss of backup in the case of both a mongodb and mysql database being dumped with the same database name

now it will dump both correctly